### PR TITLE
fix(plugin): 插件 HTTP 路由强制命名空间并加固 Gateway 入口校验

### DIFF
--- a/docs/plugin-dev-guide.md
+++ b/docs/plugin-dev-guide.md
@@ -188,12 +188,20 @@ Adapter 需实现 `IMAdapter` 接口（参考 `electron/services/im/types.ts`）
 
 在 Gateway 上注册自定义 HTTP 端点（需鉴权后才可访问）。
 
+插件路由被强制约束在 `/api/plugins/{pluginId}/` 命名空间内：传入的相对路径会自动加上该前缀。例如下面注册的实际端点是 `GET /api/plugins/my-plugin/status`：
+
 ```javascript
-api.registerHttpRoute("GET", "/api/plugin/status", (req, res) => {
+api.registerHttpRoute("GET", "/status", (req, res) => {
   res.writeHead(200, { "Content-Type": "application/json" })
   res.end(JSON.stringify({ status: "ok", version: "1.0.0" }))
 })
 ```
+
+注意：
+
+- 不得注册核心 API 保留路径（`/api/chat`、`/api/auth`、`/api/health`、`/hooks`、`/chat` 及其子路径），此类注册会被拒绝并记录错误日志。
+- 不得占用其他插件的命名空间（`/api/plugins/{其他插件id}/...`），同样会被拒绝。
+- 同一 method + path 只能有一个插件持有，冲突时保留先注册者，后注册者会被拒绝并记录错误日志。
 
 ## 使用 TypeScript
 

--- a/electron/services/GATEWAY_SPEC.md
+++ b/electron/services/GATEWAY_SPEC.md
@@ -82,7 +82,7 @@ interface AuditLogEntry {
 | `/api/chat/clear` | POST | Bearer | `handleChatClear` | 清空对话上下文 |
 | `/api/chat/events` | GET | Bearer | `handleChatEvents` | SSE 事件流（多通道旁听） |
 | `POST /hooks/:token` | POST | Token-in-URL | `handleWebhook` | 外部 Webhook 触发 Watch |
-| 插件路由（任意） | 自定义 | Bearer | 插件注册 handler | 由 `registerPluginRoutes` 注入 |
+| 插件路由 | 自定义 | Bearer | 插件注册 handler | 由 `registerPluginRoutes` 注入；路径强制约束在 `/api/plugins/{pluginId}/` 命名空间内（loader 归一化 + Gateway 入口二次校验归属与合法性），无法覆盖核心 API；method+path 冲突时保留先注册者 |
 
 ## 关键行为 / 数据流
 

--- a/electron/services/__tests__/gateway-plugin-routes.test.ts
+++ b/electron/services/__tests__/gateway-plugin-routes.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Gateway 插件路由安全边界集成测试
+ *
+ * 与 plugin-contract.test.ts 的纯函数测试互补：这里直接驱动 GatewayService 实例，
+ * 通过真实 HTTP 请求验证「鉴权 -> 插件路由校验 -> 核心 handler」的完整链路，
+ * 确保 Gateway 作为最终安全边界真的生效。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }))
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockLogError,
+    debug: vi.fn()
+  })
+}))
+
+// 模块加载层面打桩：这些重依赖不参与本测试的断言，仅避免 import 链拉进业务运行时
+vi.mock('../web-chat.service', () => ({
+  WebChatService: class {},
+  VISIBLE_STEP_TYPES: new Set()
+}))
+vi.mock('../watch/store', () => ({ getWatchStore: () => ({}) }))
+vi.mock('../sensor/event-bus', () => ({ getEventBus: () => ({ emit: vi.fn() }) }))
+
+import { GatewayService } from '../gateway.service'
+import type { HttpRouteEntry } from '../plugin/types'
+
+const TEST_TOKEN = 'test-gateway-token'
+
+function makeRoute(pluginId: string, method: string, path: string, handler?: HttpRouteEntry['handler']): HttpRouteEntry {
+  return { pluginId, method, path, handler: handler ?? (() => {}) }
+}
+
+describe('Gateway 插件路由安全边界', () => {
+  let service: GatewayService
+  let baseUrl: string
+
+  beforeEach(async () => {
+    mockLogError.mockClear()
+    service = new GatewayService()
+    service.setDependencies({ webChatService: {} as never, mainWindow: null })
+    const result = await service.start({ enabled: true, port: 0, host: '127.0.0.1', apiToken: TEST_TOKEN })
+    expect(result.success).toBe(true)
+    const address = (service as unknown as { server: { address(): { port: number } } }).server.address()
+    baseUrl = `http://127.0.0.1:${address.port}`
+  })
+
+  afterEach(async () => {
+    await service.stop()
+  })
+
+  function authHeader(): Record<string, string> {
+    return { Authorization: `Bearer ${TEST_TOKEN}` }
+  }
+
+  it('registerPluginRoutes 拒绝伪造的核心路径 entry 和归属不一致的 entry', () => {
+    service.registerPluginRoutes([
+      makeRoute('evil', 'POST', '/api/chat'),
+      makeRoute('evil', 'GET', '/api/plugins/victim/x'),
+      makeRoute('evil', 'GET', '/api/plugins/evil/../x'),
+      makeRoute('', 'GET', '/api/plugins/x/y'),
+      makeRoute('good', 'GET', '/api/plugins/good/ok')
+    ])
+
+    const routes = (service as unknown as { pluginRoutes: HttpRouteEntry[] }).pluginRoutes
+    expect(routes).toHaveLength(1)
+    expect(routes[0].pluginId).toBe('good')
+    // 每条非法 entry 都应产生一条错误日志
+    expect(mockLogError).toHaveBeenCalledTimes(4)
+  })
+
+  it('带有效 token 的 POST /api/chat 进入核心 handler，伪造插件 handler 未被调用', async () => {
+    const forgedHandler = vi.fn()
+    service.registerPluginRoutes([makeRoute('evil', 'POST', '/api/chat', forgedHandler)])
+
+    const coreSpy = vi
+      .spyOn(service as never as { handleChatMessage: (req: unknown, res: { writeHead: (n: number, h: object) => void; end: (s: string) => void }) => void }, 'handleChatMessage')
+      .mockImplementation((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ core: true }))
+      })
+
+    const res = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { ...authHeader(), 'Content-Type': 'application/json' },
+      body: '{}'
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ core: true })
+    expect(coreSpy).toHaveBeenCalledTimes(1)
+    expect(forgedHandler).not.toHaveBeenCalled()
+  })
+
+  it('不带 token 请求插件 route 返回 401，插件 handler 未被调用', async () => {
+    const pluginHandler = vi.fn((_req: unknown, res: { writeHead: (n: number) => void; end: () => void }) => {
+      res.writeHead(200)
+      res.end()
+    })
+    service.registerPluginRoutes([makeRoute('good', 'GET', '/api/plugins/good/probe', pluginHandler)])
+
+    const res = await fetch(`${baseUrl}/api/plugins/good/probe`)
+
+    expect(res.status).toBe(401)
+    expect(pluginHandler).not.toHaveBeenCalled()
+  })
+
+  it('合法插件 route 在有效 token 下正常访问', async () => {
+    service.registerPluginRoutes([
+      makeRoute('good', 'GET', '/api/plugins/good/probe', (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ marker: 'PROBE_ROUTE_ACTIVE' }))
+      })
+    ])
+
+    const res = await fetch(`${baseUrl}/api/plugins/good/probe`, { headers: authHeader() })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ marker: 'PROBE_ROUTE_ACTIVE' })
+  })
+
+  it('malformed entry 被安全拒绝，不抛异常，合法 entry 不受影响', () => {
+    const malformed: unknown[] = [
+      null,
+      undefined,
+      'not-an-object',
+      { pluginId: 'good', method: 'GET', path: undefined, handler: () => {} },
+      { pluginId: 'good', method: 'GET', path: '/api/plugins/good/x', handler: null },
+      { pluginId: 'good', method: 123, path: '/api/plugins/good/x', handler: () => {} },
+      { pluginId: 'good', method: 'GET', path: '/api/plugins/good/x' }, // 缺 handler
+      { method: 'GET', path: '/api/plugins/good/x', handler: () => {} } // 缺 pluginId
+    ]
+
+    expect(() => {
+      service.registerPluginRoutes([
+        ...malformed,
+        makeRoute('good', 'GET', '/api/plugins/good/ok')
+      ] as HttpRouteEntry[])
+    }).not.toThrow()
+
+    const routes = (service as unknown as { pluginRoutes: HttpRouteEntry[] }).pluginRoutes
+    expect(routes).toHaveLength(1)
+    expect(routes[0].path).toBe('/api/plugins/good/ok')
+    expect(mockLogError).toHaveBeenCalledTimes(malformed.length)
+  })
+
+  it('非数组 payload 不抛异常，不破坏已有路由表', () => {
+    expect(() => {
+      service.registerPluginRoutes(null as unknown as HttpRouteEntry[])
+      service.registerPluginRoutes('garbage' as unknown as HttpRouteEntry[])
+    }).not.toThrow()
+
+    const routes = (service as unknown as { pluginRoutes: HttpRouteEntry[] }).pluginRoutes
+    expect(routes).toHaveLength(0)
+    expect(mockLogError).toHaveBeenCalledTimes(2)
+  })
+
+  it('同 method+path 冲突时只保留一个 owner，并记录冲突信息', () => {
+    service.registerPluginRoutes([
+      makeRoute('good', 'GET', '/api/plugins/good/x'),
+      makeRoute('good', 'GET', '/api/plugins/good/x')
+    ])
+
+    const routes = (service as unknown as { pluginRoutes: HttpRouteEntry[] }).pluginRoutes
+    expect(routes).toHaveLength(1)
+    expect(mockLogError).toHaveBeenCalledTimes(1)
+    // 错误日志必须包含冲突的 method+path 和 pluginId，便于定位双方
+    const message = String(mockLogError.mock.calls[0][0])
+    expect(message).toContain('GET /api/plugins/good/x')
+    expect(message).toContain('good')
+  })
+})

--- a/electron/services/gateway.service.ts
+++ b/electron/services/gateway.service.ts
@@ -28,6 +28,9 @@ import { WebChatService, VISIBLE_STEP_TYPES } from './web-chat.service'
 import { createLogger } from '../utils/logger'
 import { getWatchStore } from './watch/store'
 import { getEventBus } from './sensor/event-bus'
+import type { HttpRouteEntry } from './plugin/types'
+import { PLUGIN_ROUTE_PREFIX, isCanonicalPluginRouteEntry } from './plugin/loader'
+import { resolvePluginRouteConflicts } from './plugin/registry'
 
 const log = createLogger('Gateway')
 
@@ -73,7 +76,7 @@ export class GatewayService {
   }
   private auditLog: AuditLogEntry[] = []
   private static readonly MAX_AUDIT_LOG = 500  // 最多保留 500 条记录
-  private pluginRoutes: Array<{ method: string; path: string; handler: (req: http.IncomingMessage, res: http.ServerResponse) => void | Promise<void> }> = []
+  private pluginRoutes: HttpRouteEntry[] = []
 
   /** 便捷访问 Web Chat 服务 */
   private get chat(): WebChatService {
@@ -97,13 +100,34 @@ export class GatewayService {
   }
 
   /**
-   * 注册插件 HTTP 路由
+   * 注册插件 HTTP 路由（整体替换语义）。
+   * Gateway 是安全边界的最终执行点，不信任上游输入：
+   * 1. 逐条做 canonical entry 校验（规则唯一来源是 plugin loader 的
+   *    isCanonicalPluginRouteEntry，含完整运行时类型检查），非法 entry 拒绝并记录错误；
+   * 2. 再做 method+path 冲突检测：同一 path 只能有一个 owner，冲突时拒绝后注册者。
    */
-  registerPluginRoutes(routes: Array<{ method: string; path: string; handler: (req: http.IncomingMessage, res: http.ServerResponse) => void | Promise<void> }>): void {
-    this.pluginRoutes = routes
-    if (routes.length > 0) {
-      log.info(`Registered ${routes.length} plugin HTTP route(s)`)
+  registerPluginRoutes(routes: HttpRouteEntry[]): void {
+    if (!Array.isArray(routes)) {
+      log.error('registerPluginRoutes called with non-array payload, ignoring')
+      return
     }
+    const valid = routes.filter(r => this.guardPluginRouteEntry(r))
+    this.pluginRoutes = resolvePluginRouteConflicts(valid)
+    if (this.pluginRoutes.length > 0) {
+      log.info(`Registered ${this.pluginRoutes.length} plugin HTTP route(s)`)
+    }
+  }
+
+  /** 校验单条插件路由 entry，非法时记录错误日志。规则实现见 plugin loader。 */
+  private guardPluginRouteEntry(route: unknown): boolean {
+    if (isCanonicalPluginRouteEntry(route)) return true
+    const desc = route && typeof route === 'object'
+      ? ['method', 'path', 'pluginId']
+          .map(k => `${k}: ${String((route as Record<string, unknown>)[k])}`)
+          .join(' ')
+      : String(route)
+    log.error(`Rejected illegal plugin route entry: ${desc} — path must stay under ${PLUGIN_ROUTE_PREFIX}/{pluginId}/`)
+    return false
   }
 
   /**

--- a/electron/services/plugin/SPEC.md
+++ b/electron/services/plugin/SPEC.md
@@ -46,6 +46,8 @@ api.registerHook(event: HookEvent, handler: HookHandler): void
 api.registerHttpRoute(method: string, path: string, handler: RouteHandler): void
 ```
 
+`registerHttpRoute` 的路径会被强制约束在 `/api/plugins/{pluginId}/` 命名空间内（相对路径自动加前缀）；核心 API 保留路径（`/api/chat`、`/api/auth`、`/api/health`、`/hooks`、`/chat` 及子路径）和其他插件的命名空间一律拒绝注册。同一 method + path 只允许一个 owner，冲突时保留先注册者并记录错误。
+
 ### ToolRegistration 签名
 
 ```typescript

--- a/electron/services/plugin/__tests__/plugin-contract.test.ts
+++ b/electron/services/plugin/__tests__/plugin-contract.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'path'
 
 vi.mock('../../../utils/logger', () => ({
   createLogger: () => ({
@@ -827,10 +828,12 @@ describe('发现路径契约', () => {
     })
 
     const paths: string[] = (registry as any).getDiscoveryPaths()
+    // 路径断言统一走 path.join / 分隔符归一化，保证 Windows 与 POSIX 行为一致
+    const normalize = (p: string) => p.replace(/\\/g, '/')
 
     expect(paths[0]).toBe('/custom/path')
-    expect(paths).toContain('/fake/userData/plugins')
-    expect(paths).toContain('/fake/userData/plugins/node_modules')
-    expect(paths.some((p: string) => p.includes('.openclaw/extensions'))).toBe(true)
+    expect(paths).toContain(path.join('/fake/userData', 'plugins'))
+    expect(paths).toContain(path.join('/fake/userData', 'plugins', 'node_modules'))
+    expect(paths.some((p: string) => normalize(p).includes('.openclaw/extensions'))).toBe(true)
   })
 })

--- a/electron/services/plugin/__tests__/plugin-contract.test.ts
+++ b/electron/services/plugin/__tests__/plugin-contract.test.ts
@@ -17,9 +17,9 @@ vi.mock('../../../utils/logger', () => ({
   })
 }))
 
-import { PluginRegistry } from '../registry'
+import { PluginRegistry, resolvePluginRouteConflicts } from '../registry'
 import { HookBus } from '../hook-bus'
-import { loadManifest, loadPlugin } from '../loader'
+import { loadManifest, loadPlugin, createRegistrationAPI, normalizePluginRoutePath } from '../loader'
 import type {
   PluginManifest,
   PluginEntry,
@@ -29,7 +29,9 @@ import type {
   HookEvent,
   HookDecision,
   ProviderRegistration,
-  ChannelRegistration
+  ChannelRegistration,
+  HttpRouteEntry,
+  LoadedPlugin
 } from '../types'
 
 // ==================== 1. Manifest 契约 ====================
@@ -189,7 +191,7 @@ describe('Registration API 契约', () => {
         collected.hooks.push({ event })
       },
       registerHttpRoute(method, path) {
-        plugin.httpRoutes.push({ method: method.toUpperCase(), path, handler: () => {} })
+        plugin.httpRoutes.push({ pluginId: manifest.id, method: method.toUpperCase(), path, handler: () => {} })
         collected.routes.push({ method: method.toUpperCase(), path })
       }
     })
@@ -639,8 +641,9 @@ describe('插件生命周期契约', () => {
       createAdapter: () => ({} as any)
     })
     plugin.httpRoutes.push({
+      pluginId: 'aggregation-test',
       method: 'GET',
-      path: '/test',
+      path: '/api/plugins/aggregation-test/test',
       handler: () => {}
     })
 
@@ -694,8 +697,127 @@ describe('配置契约', () => {
   })
 })
 
-// ==================== 8. 发现路径契约 ====================
+// ==================== 8. HTTP 路由命名空间与冲突契约 ====================
 
+describe('HTTP 路由命名空间与冲突契约', () => {
+  describe('normalizePluginRoutePath', () => {
+    it('普通路径自动加上插件命名空间前缀', () => {
+      expect(normalizePluginRoutePath('my-plugin', '/status')).toBe('/api/plugins/my-plugin/status')
+      expect(normalizePluginRoutePath('my-plugin', 'status')).toBe('/api/plugins/my-plugin/status')
+      expect(normalizePluginRoutePath('my-plugin', '/a/b/')).toBe('/api/plugins/my-plugin/a/b')
+      expect(normalizePluginRoutePath('my-plugin', '//a//b')).toBe('/api/plugins/my-plugin/a/b')
+    })
+
+    it('已带本插件前缀的路径原样接受（幂等）', () => {
+      expect(normalizePluginRoutePath('my-plugin', '/api/plugins/my-plugin/status'))
+        .toBe('/api/plugins/my-plugin/status')
+    })
+
+    it('命名空间根路径归一化为插件根', () => {
+      expect(normalizePluginRoutePath('my-plugin', '/')).toBe('/api/plugins/my-plugin')
+    })
+
+    it('核心保留路径一律拒绝', () => {
+      const reserved = [
+        '/api/chat',
+        '/api/chat/history',
+        '/api/auth/validate',
+        '/api/health',
+        '/hooks/some-token',
+        '/chat'
+      ]
+      for (const p of reserved) {
+        expect(normalizePluginRoutePath('my-plugin', p)).toBeNull()
+      }
+    })
+
+    it('不得占用其他插件的命名空间', () => {
+      expect(normalizePluginRoutePath('evil', '/api/plugins/victim/x')).toBeNull()
+      expect(normalizePluginRoutePath('evil', '/api/plugins')).toBeNull()
+    })
+
+    it('拒绝路径穿越和空路径', () => {
+      expect(normalizePluginRoutePath('my-plugin', '/../api/chat')).toBeNull()
+      expect(normalizePluginRoutePath('my-plugin', '')).toBeNull()
+      expect(normalizePluginRoutePath('my-plugin', '   ')).toBeNull()
+    })
+  })
+
+  describe('registerHttpRoute 注册行为', () => {
+    function createTestPlugin(): LoadedPlugin {
+      return {
+        manifest: { id: 'my-plugin', configSchema: {} },
+        rootDir: '/tmp/my-plugin',
+        tools: [],
+        providers: [],
+        channels: [],
+        ttsProviders: [],
+        hooks: new Map(),
+        httpRoutes: [],
+        enabled: true
+      }
+    }
+
+    it('注册的路由携带 pluginId 并落在命名空间内', () => {
+      const plugin = createTestPlugin()
+      const api = createRegistrationAPI('my-plugin', plugin)
+
+      api.registerHttpRoute('get', '/status', () => {})
+
+      expect(plugin.httpRoutes).toHaveLength(1)
+      expect(plugin.httpRoutes[0].pluginId).toBe('my-plugin')
+      expect(plugin.httpRoutes[0].method).toBe('GET')
+      expect(plugin.httpRoutes[0].path).toBe('/api/plugins/my-plugin/status')
+    })
+
+    it('核心路径注册被拒绝，不会进入路由表', () => {
+      const plugin = createTestPlugin()
+      const api = createRegistrationAPI('my-plugin', plugin)
+
+      api.registerHttpRoute('POST', '/api/chat', () => {})
+      api.registerHttpRoute('GET', '/api/plugins/other-plugin/x', () => {})
+
+      expect(plugin.httpRoutes).toHaveLength(0)
+    })
+  })
+
+  describe('resolvePluginRouteConflicts', () => {
+    const handler = () => {}
+    function route(pluginId: string, method: string, path: string): HttpRouteEntry {
+      return { pluginId, method, path, handler }
+    }
+
+    it('同一 method+path 只保留先注册者', () => {
+      const result = resolvePluginRouteConflicts([
+        route('plugin-a', 'GET', '/api/plugins/plugin-a/x'),
+        route('plugin-b', 'GET', '/api/plugins/plugin-a/x')
+      ])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].pluginId).toBe('plugin-a')
+    })
+
+    it('不同 method 的同 path 不冲突', () => {
+      const result = resolvePluginRouteConflicts([
+        route('plugin-a', 'GET', '/api/plugins/plugin-a/x'),
+        route('plugin-a', 'POST', '/api/plugins/plugin-a/x')
+      ])
+
+      expect(result).toHaveLength(2)
+    })
+
+    it('无冲突时原样返回', () => {
+      const result = resolvePluginRouteConflicts([
+        route('plugin-a', 'GET', '/api/plugins/plugin-a/x'),
+        route('plugin-b', 'GET', '/api/plugins/plugin-b/y')
+      ])
+
+      expect(result).toHaveLength(2)
+    })
+  })
+})
+
+// ==================== 9. 发现路径契约 ====================
 describe('发现路径契约', () => {
   it('发现路径按 SPEC 定义的优先级排列', () => {
     const registry = new PluginRegistry({

--- a/electron/services/plugin/loader.ts
+++ b/electron/services/plugin/loader.ts
@@ -19,13 +19,93 @@ import type {
   TtsProviderRegistration,
   HookEvent,
   HookHandler,
-  RouteHandler
+  RouteHandler,
+  HttpRouteEntry
 } from './types'
 import { createLogger } from '../../utils/logger'
 
 const log = createLogger('PluginLoader')
 
 const MANIFEST_FILENAME = 'openclaw.plugin.json'
+
+/** 插件 HTTP 路由的强制命名空间前缀：/api/plugins/{pluginId}/... */
+export const PLUGIN_ROUTE_PREFIX = '/api/plugins'
+
+/**
+ * Gateway 核心保留路径（无前导斜杠的归一化形式）。
+ * 插件显式注册这些路径一律拒绝，避免劫持核心端点语义。
+ */
+const RESERVED_ROUTE_PREFIXES = ['api/chat', 'api/auth', 'api/health', 'hooks', 'chat']
+
+function isReservedRoutePath(normalized: string): boolean {
+  return RESERVED_ROUTE_PREFIXES.some(
+    prefix => normalized === prefix || normalized.startsWith(prefix + '/')
+  )
+}
+
+/**
+ * 归一化插件路由路径，把插件路由强制约束在 /api/plugins/{pluginId}/ 命名空间内。
+ *
+ * - 普通路径（如 "/status"）：自动加上本插件的命名空间前缀；
+ * - 已带本插件前缀的路径：原样接受（幂等）；
+ * - 命中核心保留路径、试图占用其他插件命名空间、含 ".." 分段、空路径：返回 null，调用方应拒绝注册。
+ */
+export function normalizePluginRoutePath(pluginId: string, rawPath: string): string | null {
+  // pluginId 本身必须是一个合法的单段路径分量，否则命名空间约束无从谈起
+  if (!pluginId || pluginId.includes('/') || pluginId.includes('..')) return null
+  if (typeof rawPath !== 'string' || !rawPath.trim()) return null
+
+  // 去掉多余斜杠，统一成分段形式
+  const segments = rawPath.split('/').filter(s => s.length > 0)
+  if (segments.includes('..')) return null
+
+  const joined = segments.join('/')
+
+  // 插件自己的命名空间根：/api/plugins/{pluginId}
+  if (joined === '') return `${PLUGIN_ROUTE_PREFIX}/${pluginId}`
+
+  // 已带 /api/plugins/ 前缀：只允许落在本插件自己的命名空间内
+  if (joined === 'api/plugins' || joined.startsWith('api/plugins/')) {
+    const rest = joined.slice('api/plugins/'.length)
+    const owner = rest.split('/')[0]
+    if (!rest || owner !== pluginId) return null
+    return `${PLUGIN_ROUTE_PREFIX}/${rest}`
+  }
+
+  // 显式指向核心 API 路径：拒绝并给出明确错误，而不是静默改名
+  if (isReservedRoutePath(joined)) return null
+
+  return `${PLUGIN_ROUTE_PREFIX}/${pluginId}/${joined}`
+}
+
+/**
+ * 校验一条插件路由 entry 是否为合法的 canonical 形态。
+ *
+ * 这是 loader 归一化规则的唯一权威校验方，Gateway 在注册入口直接复用本函数，
+ * 双方不各自维护规则，避免校验逻辑漂移。
+ *
+ * 运行时完整校验（不信任 TypeScript 类型）：entry 必须是非空对象，
+ * method/path/pluginId 必须是非空字符串，handler 必须是函数；
+ * pluginId 不得含 "/" 或 ".."，path 不得含 ".." 分段；
+ * path 必须落在该插件自己的 /api/plugins/{pluginId}/ 命名空间内。
+ */
+export function isCanonicalPluginRouteEntry(route: unknown): route is HttpRouteEntry {
+  if (!route || typeof route !== 'object') return false
+
+  const r = route as Partial<Record<keyof HttpRouteEntry, unknown>>
+  if (typeof r.method !== 'string' || r.method.length === 0) return false
+  if (typeof r.path !== 'string' || r.path.length === 0) return false
+  if (typeof r.handler !== 'function') return false
+
+  const pluginId = r.pluginId
+  if (typeof pluginId !== 'string' || pluginId.length === 0) return false
+  if (pluginId.includes('/') || pluginId.includes('..')) return false
+
+  if (r.path.split('/').includes('..')) return false
+
+  const prefix = `${PLUGIN_ROUTE_PREFIX}/${pluginId}`
+  return r.path === prefix || r.path.startsWith(prefix + '/')
+}
 
 /**
  * 从指定目录扫描所有插件目录
@@ -140,7 +220,11 @@ export async function loadPlugin(
   return plugin
 }
 
-function createRegistrationAPI(pluginId: string, plugin: LoadedPlugin): PluginRegistrationAPI {
+/**
+ * 构建传给插件 register(api) 的注册 API。
+ * 导出供契约测试直接验证注册行为（命名空间、拒绝逻辑）。
+ */
+export function createRegistrationAPI(pluginId: string, plugin: LoadedPlugin): PluginRegistrationAPI {
   return {
     registerTool(def: ToolRegistration, opts?: ToolRegistrationOptions) {
       plugin.tools.push({ ...def, optional: opts?.optional })
@@ -168,8 +252,19 @@ function createRegistrationAPI(pluginId: string, plugin: LoadedPlugin): PluginRe
       log.debug(`Plugin "${pluginId}" registered hook: ${event}`)
     },
     registerHttpRoute(method: string, routePath: string, handler: RouteHandler) {
-      plugin.httpRoutes.push({ method: method.toUpperCase(), path: routePath, handler })
-      log.debug(`Plugin "${pluginId}" registered route: ${method.toUpperCase()} ${routePath}`)
+      const normalized = normalizePluginRoutePath(pluginId, routePath)
+      if (!normalized) {
+        log.error(
+          `Plugin "${pluginId}" route rejected: ${method.toUpperCase()} ${routePath} ` +
+          `(routes must stay under ${PLUGIN_ROUTE_PREFIX}/${pluginId}/ and must not target core API paths)`
+        )
+        return
+      }
+      if (normalized !== routePath) {
+        log.info(`Plugin "${pluginId}" route namespaced: ${method.toUpperCase()} ${routePath} -> ${normalized}`)
+      }
+      plugin.httpRoutes.push({ pluginId, method: method.toUpperCase(), path: normalized, handler })
+      log.debug(`Plugin "${pluginId}" registered route: ${method.toUpperCase()} ${normalized}`)
     }
   }
 }

--- a/electron/services/plugin/registry.ts
+++ b/electron/services/plugin/registry.ts
@@ -391,6 +391,34 @@ function registerSdkShim(): void {
   }
 }
 
+// ==================== 路由冲突检测 ====================
+
+/**
+ * 解决插件路由冲突：同一 method + path 只能有一个 owner。
+ * 保留先注册者，拒绝后来者并记录明确错误（含双方 pluginId）。
+ * Gateway 在 registerPluginRoutes 时应用此函数。
+ */
+export function resolvePluginRouteConflicts(routes: HttpRouteEntry[]): HttpRouteEntry[] {
+  const seen = new Map<string, HttpRouteEntry>()
+  const result: HttpRouteEntry[] = []
+
+  for (const route of routes) {
+    const key = `${route.method} ${route.path}`
+    const existing = seen.get(key)
+    if (existing) {
+      log.error(
+        `Plugin route conflict: ${key} is already owned by plugin "${existing.pluginId}", ` +
+        `rejected duplicate registration from plugin "${route.pluginId}"`
+      )
+      continue
+    }
+    seen.set(key, route)
+    result.push(route)
+  }
+
+  return result
+}
+
 // ==================== 单例工厂 ====================
 
 let instance: PluginRegistry | null = null

--- a/electron/services/plugin/types.ts
+++ b/electron/services/plugin/types.ts
@@ -120,6 +120,8 @@ export type RouteHandler = (
 
 /** HTTP 路由注册项 */
 export interface HttpRouteEntry {
+  /** 路由归属的插件 id（撤销、冲突检测与审计的凭据） */
+  pluginId: string
   method: string
   path: string
   handler: RouteHandler


### PR DESCRIPTION
## 问题

插件通过 `api.registerHttpRoute()` 可以注册任意路径，Gateway 在固定 API switch 之前匹配插件路由，
因此插件可以注册 `/api/chat`、`/api/chat/history` 等核心路径，在请求已通过 Bearer 鉴权的前提下
劫持核心端点语义。同时同 method+path 的重复注册会被静默遮蔽，无任何报错。

实机复现（SailFish 11.8.0 安装版 + 最小复现插件）：插件注册 `POST /api/chat` 后，
携带有效 token 请求该端点收到的是插件返回的 418 响应，而非核心 handler 的处理结果。
<img width="469" height="172" alt="test1" src="https://github.com/user-attachments/assets/d49c93f4-fba6-45bf-81d1-0f4fcb77d442" />


## 修复内容

1. **loader 强制命名空间**：`registerHttpRoute()` 的路径统一归一化到
   `/api/plugins/{pluginId}/` 下；显式注册核心保留路径（`/api/chat`、`/api/auth`、
   `/api/health`、`/hooks`、`/chat` 及子路径）或其他插件命名空间时拒绝注册并记录错误日志。
2. **HttpRouteEntry 增加 `pluginId` owner 字段**，为冲突检测、审计和后续禁用撤销提供凭据。
3. **Gateway 入口二次校验**：`registerPluginRoutes()` 不信任上游输入，逐条校验 canonical
   形态（完整运行时类型检查，malformed entry 安全拒绝不抛异常），校验规则唯一来源是
   loader 的 `isCanonicalPluginRouteEntry()`，避免两处规则漂移。
4. **冲突检测**：同一 method+path 只保留先注册者，冲突时记录含双方 pluginId 的错误日志。

## 兼容性

- 普通相对路径自动加前缀，已有插件的正常路由不受影响（行为软落地）；
- 注册核心路径的插件会被拒绝该条路由并看到明确错误日志——这正是本修复的目的。

## 范围说明（不在本 PR 内）

- 禁用插件后 Gateway 中已注册路由的会话内撤销：依赖本次引入的 owner 字段，
  将在后续生命周期 PR 中处理（需要同时编排 AiService/TTS/IM 的撤销）；
- "冲突即注册失败"的语义升级：需要两阶段注册，另行讨论。

## 测试

- 新增 Gateway 真实 HTTP 集成测试（`gateway-plugin-routes.test.ts`，7 条）：
  伪造 entry 拒绝、核心 handler 不被遮蔽、无 token 401、合法路由可用、冲突去重、
  malformed entry 安全拒绝、非数组 payload 不抛异常；
- 插件契约测试新增命名空间/拒绝/冲突用例；
- 本地全量通过（52/52）；ESLint 无告警；typecheck 无新增错误（基线既有错误未动）。

另含一个独立 commit：`test(plugin): 发现路径契约断言兼容 Windows 路径分隔符`——
修复 Windows 下既有的断言失败（与主修复无关，POSIX 行为不变）。